### PR TITLE
Cross-platform/Linux default directory support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ url = "2.5"
 async-trait = "0.1"
 
 dotenvy = "0.15"
+directories = "6.0.0"
 
 [profile.release]
 opt-level = "z"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+#For more settings refer to https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
+[toolchain]
+channel = "nightly"
+components = [ "clippy", "rustfmt", "rust-analyzer"]

--- a/src/app/settings/store.rs
+++ b/src/app/settings/store.rs
@@ -1,12 +1,39 @@
 // Settings store: data types, global state, load/save, and records of downloaded games.
 
+use directories::{ProjectDirs, UserDirs};
 use lazy_static::lazy_static;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::path::PathBuf;
 use std::sync::RwLock;
 
+lazy_static! {
+    pub static ref PROJECT_DIRS: Option<ProjectDirs> =
+        ProjectDirs::from("org", "farvend", "F95-Manager");
+}
+
 fn default_cache_dir() -> PathBuf {
-    PathBuf::from("cache")
+    PROJECT_DIRS
+        .as_ref()
+        .map(|dirs| dirs.cache_dir().into())
+        .unwrap_or(PathBuf::from("cache"))
+}
+
+fn default_downloads_dir() -> PathBuf {
+    UserDirs::new()
+        .and_then(|u| u.download_dir().map(|d| d.into()))
+        .unwrap_or(PathBuf::from("downloads"))
+}
+
+fn default_games_dir() -> PathBuf {
+    let mut home: PathBuf = UserDirs::new()
+        .map(|u| u.home_dir().into())
+        .unwrap_or_default();
+
+    #[cfg(target_os = "windows")]
+    home.push("games");
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "ios"))]
+    home.push("Games");
+    home
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -80,10 +107,14 @@ pub struct AppSettings {
 
 impl Default for AppSettings {
     fn default() -> Self {
+        let temp_dir = default_downloads_dir();
+        let extract_dir = default_games_dir();
+        let cache_dir = default_cache_dir();
+
         Self {
-            temp_dir: PathBuf::from("downloads"),
-            extract_dir: PathBuf::from("games"),
-            cache_dir: PathBuf::from("cache"),
+            temp_dir,
+            extract_dir,
+            cache_dir,
             downloaded_games: Vec::new(),
             pending_downloads: Vec::new(),
             hidden_threads: Vec::new(),
@@ -107,7 +138,7 @@ fn default_log_to_file() -> bool {
     true
 }
 
-//// Serde helpers for language field to keep backward compatibility with older JSONs.
+/// Serde helpers for language field to keep backward compatibility with older JSONs.
 fn deserialize_language_opt<'de, D>(
     deserializer: D,
 ) -> Result<Option<crate::localization::SupportedLang>, D::Error>


### PR DESCRIPTION
Привет!
rust-toolchain.toml specifies channel which rust should be pulled from. README notes that we should build with stable, while code has nightly features required (should code be stable by default or nightly?).
"directories" is a useful dependency for cross-platform resolution and relative directories. Prefer to use PROJECT_DIRS  where possible for good cross-platform support.
Linux doesn't have "Games" directory out of the gate, but Wine/Proton will create it in some cases for windows games (for compatibility?) so it's common nonetheless.